### PR TITLE
Robustify empty JS block comment stripping

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -11,6 +11,14 @@ const compile = (cst, options = {}) => {
 
     for (const child of node.nodes) {
       switch (child.type) {
+        case 'empty-block':
+          if (options.first && firstSeen === true) {
+            output += walk(child, node);
+            break;
+          }
+
+          firstSeen = true;
+          break;
         case 'block':
           if (options.first && firstSeen === true) {
             output += walk(child, node);

--- a/lib/languages.js
+++ b/lib/languages.js
@@ -28,6 +28,9 @@ exports.html = {
 
 exports.javascript = {
   BLOCK_OPEN_REGEX: /^\/\*\*?(!?)/,
+  BLOCK_EMPTY_REGEX: /^\/\*\*\//,
+  // BLOCK_OPEN_REGEX: /^\/\*/,
+  // BLOCK_OPEN_IMPORTANT_REGEX: /^\/\*\*?(!?)/,
   BLOCK_CLOSE_REGEX: /^\*\/(\n?)/,
   LINE_REGEX: /^\/\/(!?).*/
 };

--- a/lib/languages.js
+++ b/lib/languages.js
@@ -29,8 +29,6 @@ exports.html = {
 exports.javascript = {
   BLOCK_OPEN_REGEX: /^\/\*\*?(!?)/,
   BLOCK_EMPTY_REGEX: /^\/\*\*\//,
-  // BLOCK_OPEN_REGEX: /^\/\*/,
-  // BLOCK_OPEN_IMPORTANT_REGEX: /^\/\*\*?(!?)/,
   BLOCK_CLOSE_REGEX: /^\*\/(\n?)/,
   LINE_REGEX: /^\/\/(!?).*/
 };

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -23,7 +23,7 @@ const parse = (input, options = {}) => {
     throw new Error(`Language "${name}" is not supported by strip-comments`);
   }
 
-  const { LINE_REGEX, BLOCK_OPEN_REGEX, BLOCK_CLOSE_REGEX } = lang;
+  const { LINE_REGEX, BLOCK_EMPTY_REGEX, BLOCK_OPEN_REGEX, BLOCK_CLOSE_REGEX } = lang;
   let block = cst;
   let remaining = input;
   let token;
@@ -34,10 +34,6 @@ const parse = (input, options = {}) => {
 
   if (source.every(regex => regex.source === '^"""')) {
     tripleQuotes = true;
-  }
-
-  if (name === 'javascript') {
-    remaining = remaining.replace(/\/\*\*\//gu, '');
   }
 
   /**
@@ -101,6 +97,16 @@ const parse = (input, options = {}) => {
     if ((token = scan(constants.NEWLINE_REGEX, 'newline'))) {
       push(new Node(token));
       continue;
+    }
+
+    // empty block comment
+    // This exists to handle the edge case of "/**/" in JavaScript, which is
+    // not handled by the regular open / close block comment logic.
+    if (BLOCK_EMPTY_REGEX && options.block && !(tripleQuotes && block.type === 'block')) {
+      if ((token = scan(BLOCK_EMPTY_REGEX , 'empty-block'))) {
+        push(new Node(token));
+        continue;
+      }
     }
 
     // block comment open

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nodefactory/strip-comments",
   "description": "Strip line and/or block comments from a string. Blazing fast, and works with JavaScript, Sass, CSS, Less.js, and a number of other languages.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "homepage": "https://github.com/jonschlinkert/strip-comments",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "repository": "jonschlinkert/strip-comments",

--- a/test/JavaScript.js
+++ b/test/JavaScript.js
@@ -28,11 +28,6 @@ describe('JavaScript comments', () => {
     assert.strictEqual(actual, '\'foo\'; \n var abc = \'xyz\';');
   });
 
-  it('should strip js commend in edge case', () => {
-    const actual = strip("hello/**/ world");
-    assert.strictEqual(actual, 'hello world');
-  });
-
   it('should work on unclosed (invalid) blocks', () => {
     const actual = strip("'foo'; /* I am invalid ");
     assert.strictEqual(actual, '\'foo\'; ');
@@ -55,6 +50,31 @@ describe('JavaScript comments', () => {
     const actual = strip.block('foo // this is a comment\n/* me too */');
     const expected = 'foo // this is a comment\n';
     assert.strictEqual(actual, expected);
+  });
+
+  it('should strip empty js block comment in edge case', () => {
+    const actual = strip("hello/**/ world");
+    assert.strictEqual(actual, 'hello world');
+  });
+
+  it('should strip empty js block comment in edge case with succeeding line comment', () => {
+    const actual = strip("hello/**/ world // foo");
+    assert.strictEqual(actual, 'hello world ');
+  });
+
+  it('should strip empty js block comment in edge case with succeeding block comment', () => {
+    const actual = strip("hello/**/ world /** foo */");
+    assert.strictEqual(actual, 'hello world ');
+  });
+
+  it('should strip empty js block comment in edge case with option: first', () => {
+    const actual = strip("hello/**/ world // foo", { first: true });
+    assert.strictEqual(actual, 'hello world // foo');
+  });
+
+  it('should not strip empty js block comment in string literal', () => {
+    const actual = strip("var bar = '/**/'");
+    assert.strictEqual(actual, "var bar = '/**/'");
   });
 
   // see https://github.com/jonschlinkert/strip-comments/issues/31


### PR DESCRIPTION
#4 introduced stripping `/**/` comments without mangling the remainder of the string, however it did so using a global regular expression instead of using this package's parsing and compiling logic. The approach in #4 would, for example, remove the token `/**/` from string literals, which could change the runtime behavior of a program.

This PR removes the regular expression introduced in #4, and incorporates stripping of empty block comments via this package's parsing and compilation logic, which ensures that the token `/**/` will be reliably removed if and only if it is in fact an empty block comment. (Insofar as the parsing / compilation logic of this package is already correct.)