### PR TITLE
Fix issue with nested comments

### DIFF
--- a/lib/languages.js
+++ b/lib/languages.js
@@ -30,7 +30,8 @@ exports.javascript = {
   BLOCK_OPEN_REGEX: /^\/\*\*?(!?)/,
   BLOCK_EMPTY_REGEX: /^\/\*\*\//,
   BLOCK_CLOSE_REGEX: /^\*\/(\n?)/,
-  LINE_REGEX: /^\/\/(!?).*/
+  LINE_REGEX: /^\/\/(!?).*/,
+  disallowNestedComments: true
 };
 
 exports.lua = {
@@ -51,7 +52,8 @@ exports.perl = {
 
 exports.php = {
   ...exports.javascript,
-  LINE_REGEX: /^(#|\/\/).*?(?=\?>|\n)/
+  LINE_REGEX: /^(#|\/\/).*?(?=\?>|\n)/,
+  disallowNestedComments: false
 };
 
 exports.python = {
@@ -70,7 +72,15 @@ exports.shebang = exports.hashbang = {
   LINE_REGEX: /^#!.*/
 };
 
-exports.c = exports.javascript;
+exports.c = {
+  ...exports.javascript,
+  disallowNestedComments: false
+};
+exports.swift = {
+  ...exports.javascript,
+  disallowNestedComments: false
+};
+
 exports.csharp = exports.javascript;
 exports.css = exports.javascript;
 exports.java = exports.javascript;
@@ -80,7 +90,6 @@ exports.pascal = exports.applescript;
 exports.ocaml = exports.applescript;
 exports.sass = exports.javascript;
 exports.sql = exports.ada;
-exports.swift = exports.javascript;
 exports.ts = exports.javascript;
 exports.typscript = exports.javascript;
 exports.xml = exports.html;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -109,9 +109,9 @@ const parse = (input, options = {}) => {
       }
     }
 
-    const isInsideBlock = (block.type !== 'block' && disallowNestedComments) || !disallowNestedComments;
+    const allowBlockCommentOpen = (block.type !== 'block' && disallowNestedComments) || !disallowNestedComments;
     // block comment open
-    if (BLOCK_OPEN_REGEX && options.block && !(tripleQuotes && block.type === 'block') && isInsideBlock) {
+    if (BLOCK_OPEN_REGEX && options.block && !(tripleQuotes && block.type === 'block') && allowBlockCommentOpen) {
       if ((token = scan(BLOCK_OPEN_REGEX, 'open'))) {
         push(new Block({ type: 'block' }));
         push(new Node(token));

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -23,7 +23,7 @@ const parse = (input, options = {}) => {
     throw new Error(`Language "${name}" is not supported by strip-comments`);
   }
 
-  const { LINE_REGEX, BLOCK_EMPTY_REGEX, BLOCK_OPEN_REGEX, BLOCK_CLOSE_REGEX } = lang;
+  const { LINE_REGEX, BLOCK_EMPTY_REGEX, BLOCK_OPEN_REGEX, BLOCK_CLOSE_REGEX, disallowNestedComments } = lang;
   let block = cst;
   let remaining = input;
   let token;
@@ -109,8 +109,9 @@ const parse = (input, options = {}) => {
       }
     }
 
+    const isInsideBlock = (block.type !== 'block' && disallowNestedComments) || !disallowNestedComments;
     // block comment open
-    if (BLOCK_OPEN_REGEX && options.block && !(tripleQuotes && block.type === 'block')) {
+    if (BLOCK_OPEN_REGEX && options.block && !(tripleQuotes && block.type === 'block') && isInsideBlock) {
       if ((token = scan(BLOCK_OPEN_REGEX, 'open'))) {
         push(new Block({ type: 'block' }));
         push(new Node(token));

--- a/test/JavaScript.js
+++ b/test/JavaScript.js
@@ -77,6 +77,16 @@ describe('JavaScript comments', () => {
     assert.strictEqual(actual, "var bar = '/**/'");
   });
 
+  it('should allow /* inside block comments', () => {
+    const actual = strip("foo /** /* **/bar");
+    assert.strictEqual(actual, 'foo bar');
+  });
+
+  it('should allow /** inside block comments', () => {
+    const actual = strip("foo /** /** **/bar");
+    assert.strictEqual(actual, 'foo bar');
+  });
+
   // see https://github.com/jonschlinkert/strip-comments/issues/31
   it('should only strip the first comment', () => {
     const expected = read(tests('expected/banner.js'));


### PR DESCRIPTION
Added a check to determine whether we are already inside a comment block, in JS it is allowed to use `/*` inside a comment block, but nested comments are not allowed. I disabled this feature for a few other languages which were failing tests after the change.